### PR TITLE
import pip.req for different pip version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,8 @@
 from distutils.core import setup
-from pip.req import parse_requirements
+try: # for pip >= 10
+    from pip._internal.req import parse_requirements
+except ImportError: # for pip <= 9.0.3
+    from pip.req import parse_requirements
 
 setup(
   name='speechT',


### PR DESCRIPTION
I met ImportError: No module named 'pip.req' while installing.